### PR TITLE
Remove caching in `ChecksumTree`

### DIFF
--- a/src/checksum/nodes.rs
+++ b/src/checksum/nodes.rs
@@ -127,6 +127,72 @@ impl EntryChecksum {
     }
 }
 
+/// Struct for computing the checksum for a directory.  After creation,
+/// [`push()`][Dirsummer::push] the checksums for each directory entry and then
+/// call [`checksum()`][Dirsummer::checksum] to fetch the directory's checksum.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Dirsummer {
+    relpath: EntryPath,
+    files: Vec<FileChecksum>,
+    directories: Vec<DirChecksum>,
+    size: u64,
+    file_count: u64,
+}
+
+impl Dirsummer {
+    pub fn new(relpath: EntryPath) -> Dirsummer {
+        Dirsummer {
+            relpath,
+            files: Vec::new(),
+            directories: Vec::new(),
+            size: 0,
+            file_count: 0,
+        }
+    }
+
+    /// Return the path within the Zarr for the directory
+    pub fn relpath(&self) -> &EntryPath {
+        &self.relpath
+    }
+
+    /// Add a checksum for an entry of the directory.
+    ///
+    /// It is the caller's responsibility to ensure that `chksum` actually
+    /// belongs to an entry in the on-disk directory and that `push()` is not
+    /// called with two different checksums with the same
+    /// [`name`][Checksum::name].  If these conditions are not met,
+    /// [`checksum()`][Dirsummer::checksum] will return an inaccurate value.
+    pub fn push<N: Into<EntryChecksum>>(&mut self, chksum: N) {
+        let node = chksum.into();
+        self.size += node.size();
+        self.file_count += node.file_count();
+        match node {
+            EntryChecksum::File(f) => self.files.push(f),
+            EntryChecksum::Directory(d) => self.directories.push(d),
+        }
+    }
+
+    /// Compute the checksum for the directory based on the entry checksums
+    /// added so far
+    pub fn checksum(&self) -> DirChecksum {
+        let md5 = md5_string(&get_checksum_json(
+            self.files.iter(),
+            self.directories.iter(),
+        ));
+        let checksum = format!("{}-{}--{}", md5, self.file_count, self.size);
+        debug!(
+            "Computed checksum for directory {}: {}",
+            self.relpath, checksum
+        );
+        DirChecksum {
+            relpath: self.relpath.clone(),
+            checksum,
+            size: self.size,
+            file_count: self.file_count,
+        }
+    }
+}
+
 /// Compute the checksum for the directory at relative path `relpath` within a
 /// Zarr, where the entries of the directory have the checksums supplied in
 /// `iter`.
@@ -151,7 +217,7 @@ where
             EntryChecksum::Directory(d) => directories.push(d),
         }
     }
-    let md5 = md5_string(&get_checksum_json(files, directories));
+    let md5 = md5_string(&get_checksum_json(files.iter(), directories.iter()));
     let checksum = format!("{md5}-{file_count}--{size}");
     debug!("Computed checksum for directory {relpath}: {checksum}");
     DirChecksum {
@@ -251,5 +317,103 @@ mod test {
         ];
         let checksum = get_checksum("foo".try_into().unwrap(), nodes);
         assert_eq!(checksum.checksum, "d5e4eb5dc8efdb54ff089db1eef34119-2--2");
+    }
+
+    #[test]
+    fn test_dirsummer_nothing() {
+        let ds = Dirsummer::new("foo".try_into().unwrap());
+        assert_eq!(
+            ds.checksum().checksum,
+            "481a2f77ab786a0f45aafd5db0971caa-0--0"
+        );
+    }
+
+    #[test]
+    fn test_dirsummer_one_file() {
+        let mut ds = Dirsummer::new("foo".try_into().unwrap());
+        ds.push(FileChecksum {
+            relpath: "bar".try_into().unwrap(),
+            checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            size: 1,
+        });
+        assert_eq!(
+            ds.checksum().checksum,
+            "f21b9b4bf53d7ce1167bcfae76371e59-1--1"
+        );
+    }
+
+    #[test]
+    fn test_dirsummer_one_directory() {
+        let mut ds = Dirsummer::new("foo".try_into().unwrap());
+        ds.push(DirChecksum {
+            relpath: "bar".try_into().unwrap(),
+            checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1--1".into(),
+            size: 1,
+            file_count: 1,
+        });
+        assert_eq!(
+            ds.checksum().checksum,
+            "ea8b8290b69b96422a3ed1cca0390f21-1--1"
+        );
+    }
+
+    #[test]
+    fn test_dirsummer_two_files() {
+        let mut ds = Dirsummer::new("foo".try_into().unwrap());
+        ds.push(FileChecksum {
+            relpath: "bar".try_into().unwrap(),
+            checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            size: 1,
+        });
+        ds.push(FileChecksum {
+            relpath: "baz".try_into().unwrap(),
+            checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into(),
+            size: 1,
+        });
+        assert_eq!(
+            ds.checksum().checksum,
+            "8e50add2b46d3a6389e2d9d0924227fb-2--2"
+        );
+    }
+
+    #[test]
+    fn test_dirsummer_two_directories() {
+        let mut ds = Dirsummer::new("foo".try_into().unwrap());
+        ds.push(DirChecksum {
+            relpath: "bar".try_into().unwrap(),
+            checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1--1".into(),
+            size: 1,
+            file_count: 1,
+        });
+        ds.push(DirChecksum {
+            relpath: "baz".try_into().unwrap(),
+            checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1--1".into(),
+            size: 1,
+            file_count: 1,
+        });
+        assert_eq!(
+            ds.checksum().checksum,
+            "4c21a113688f925240549b14136d61ff-2--2"
+        );
+    }
+
+    #[test]
+    fn test_dirsummer_one_of_each() {
+        let mut ds = Dirsummer::new("foo".try_into().unwrap());
+        ds.push(EntryChecksum::File(FileChecksum {
+            relpath: "baz".try_into().unwrap(),
+            checksum: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            size: 1,
+        }));
+        ds.push(EntryChecksum::Directory(DirChecksum {
+            relpath: "bar".try_into().unwrap(),
+            checksum: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-1--1".into(),
+            size: 1,
+            file_count: 1,
+        }));
+        assert_eq!(
+            ds.checksum().checksum,
+            "d5e4eb5dc8efdb54ff089db1eef34119-2--2"
+        );
     }
 }

--- a/src/checksum/tree.rs
+++ b/src/checksum/tree.rs
@@ -123,10 +123,9 @@ impl DirTree {
         self.checksum_cache
             .borrow_mut()
             .get_or_insert_with(|| {
-                get_checksum(
-                    self.relpath.clone(),
-                    self.children.values().map(TreeNode::to_checksum),
-                )
+                let mut ds = Dirsummer::new(self.relpath.clone());
+                ds.extend(self.children.values().map(TreeNode::to_checksum));
+                ds.checksum()
             })
             .clone()
     }
@@ -139,10 +138,9 @@ impl DirTree {
 impl From<DirTree> for DirChecksum {
     fn from(dirtree: DirTree) -> DirChecksum {
         dirtree.checksum_cache.take().unwrap_or_else(|| {
-            get_checksum(
-                dirtree.relpath,
-                dirtree.children.into_values().map(EntryChecksum::from),
-            )
+            let mut ds = Dirsummer::new(dirtree.relpath);
+            ds.extend(dirtree.children.into_values().map(EntryChecksum::from));
+            ds.checksum()
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ impl Arguments {
                 &Zarr::new(dirpath).exclude_dotfiles(self.exclude_dotfiles),
                 threads,
             )
-            .map(|chktree| termtree::Tree::from(chktree).to_string()),
+            .map(|chktree| chktree.into_termtree().to_string()),
         }
     }
 }

--- a/src/walkers/recursive.rs
+++ b/src/walkers/recursive.rs
@@ -26,12 +26,12 @@ pub fn recursive_checksum(zarr: &Zarr) -> Result<String, ChecksumError> {
 }
 
 fn recurse(zdir: ZarrDirectory) -> Result<DirChecksum, FSError> {
-    let mut nodes: Vec<EntryChecksum> = Vec::new();
+    let mut ds = zdir.dirsummer();
     for entry in zdir.entries()? {
         match entry {
-            ZarrEntry::File(f) => nodes.push(f.into_checksum()?.into()),
-            ZarrEntry::Directory(d) => nodes.push(recurse(d)?.into()),
+            ZarrEntry::File(f) => ds.push(f.into_checksum()?),
+            ZarrEntry::Directory(d) => ds.push(recurse(d)?),
         }
     }
-    Ok(zdir.get_checksum(nodes))
+    Ok(ds.checksum())
 }

--- a/src/zarr.rs
+++ b/src/zarr.rs
@@ -163,6 +163,15 @@ impl ZarrDirectory {
         Ok(entries)
     }
 
+    pub fn dirsummer(&self) -> Dirsummer {
+        let relpath = match &self.relpath {
+            // TODO: Replace this kludgy workaround with something better:
+            DirPath::Root => EntryPath::try_from("<root>").unwrap(),
+            DirPath::Path(ep) => ep.clone(),
+        };
+        Dirsummer::new(relpath)
+    }
+
     /// Compute the checksum for the directory from the given checksums for the
     /// directory's entries.
     ///
@@ -174,12 +183,9 @@ impl ZarrDirectory {
     where
         I: IntoIterator<Item = EntryChecksum>,
     {
-        let relpath = match &self.relpath {
-            // TODO: Replace this kludgy workaround with something better:
-            DirPath::Root => EntryPath::try_from("<root>").unwrap(),
-            DirPath::Path(ep) => ep.clone(),
-        };
-        get_checksum(relpath, nodes)
+        let mut ds = self.dirsummer();
+        ds.extend(nodes);
+        ds.checksum()
     }
 }
 


### PR DESCRIPTION
* Added a `Dirsummer` builder struct for computing the checksum for a directory
* Replaced `get_checksum()` with `Dirsummer`
* Used `Dirsummer` to rewrite the conversion from `ChecksumTree` to `termtree::Tree`, eliminating the need for caching
* Removed caching in `ChecksumTree`